### PR TITLE
Fix wrong instruction on non-normative http migration

### DIFF
--- a/docs/non-normative/http-migration.md
+++ b/docs/non-normative/http-migration.md
@@ -123,7 +123,7 @@ Metric changes:
 - **Name**: `http.client.duration` &rarr; `http.client.request.duration`
 - **Unit**: `ms` &rarr; `s`
 - **Description**: `Measures the duration of inbound HTTP requests.` &rarr;
-  `Duration of HTTP server requests.`
+  `Duration of HTTP client requests.`
 - **Histogram buckets**: boundaries updated to reflect change from milliseconds
   to seconds, and zero bucket boundary removed
 - **Attributes**: see table below


### PR DESCRIPTION
Small change. I had to consult this page today to check the guidelines to review code from python SDK and noticed that the instrunction differs from what is defined in semconv.